### PR TITLE
Add test for follow_links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /Cargo.lock
+/tests/symlink-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
   The default is `true`, in line with the existing behavior.
   ([ticket](https://github.com/rust-lang/glob/issues/62))
   ([contributed by arilou](https://github.com/mtkennerly/globetter/pull/1))
+* Avoided an extra `metadata` lookup when:
+  * a match is found on Linux and `case_sensitive` is true
+  * a match is found on Windows/Mac and `case_sensitive` is false
 
 ## v0.1.1 (2022-10-07)
 


### PR DESCRIPTION
@arilou I added a test for the new option from #1. I also noticed there was another `fs::metadata` call outside of `is_dir`, so I applied the new option to it as well.